### PR TITLE
Pass DerivedData location as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ steps:
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
-| `derived_data_path` | Path of the project's derived data folder | required | `~/Library/Developer/Xcode/DerivedData/**` |
+| `derived_data_path` | Path of the project's Derived Data folder. Supports glob patterns. | required | `~/Library/Developer/Xcode/DerivedData/**` |
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ steps:
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
+| `derived_data_path` | Path of the project's derived data folder | required | `~/Library/Developer/Xcode/DerivedData/**` |
 </details>
 
 <details>

--- a/step.yml
+++ b/step.yml
@@ -36,6 +36,12 @@ deps:
   - name: zstd
 
 inputs:
+- derived_data_path: ~/Library/Developer/Xcode/DerivedData/**
+  opts:
+    title: Derived Data Path
+    summary: Path of the project's Derived Data folder.
+    description: Path of the project's Derived Data folder. Supports glob patterns.
+    is_required: true
 - verbose: "false"
   opts:
     title: Verbose logging
@@ -44,9 +50,3 @@ inputs:
     value_options:
     - "true"
     - "false"
-- derived_data_path: ~/Library/Developer/Xcode/DerivedData/**
-  opts:
-    title: Derived Data Path
-    summary: Path of the project's Derived Data folder.
-    description: Path of the project's Derived Data folder. Supports glob patterns.
-    is_required: true

--- a/step.yml
+++ b/step.yml
@@ -44,3 +44,9 @@ inputs:
     value_options:
     - "true"
     - "false"
+- derived_data_path: "~/Library/Developer/Xcode/DerivedData/**"
+  opts:
+    title: Derived Data Path
+    summary: Path of the project's Derived Data folder.
+    description: Path of the project's Derived Data folder. Supports glob patterns.
+    is_required: true

--- a/step.yml
+++ b/step.yml
@@ -44,7 +44,7 @@ inputs:
     value_options:
     - "true"
     - "false"
-- derived_data_path: "~/Library/Developer/Xcode/DerivedData/**"
+- derived_data_path: ~/Library/Developer/Xcode/DerivedData/**
   opts:
     title: Derived Data Path
     summary: Path of the project's Derived Data folder.

--- a/step/step.go
+++ b/step/step.go
@@ -2,6 +2,7 @@ package step
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/bitrise-io/go-steputils/v2/cache"
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
@@ -17,11 +18,11 @@ const (
 	// OS + Arch: SPM works on Linux too, and Intel/ARM difference is important on macOS
 	// checksum: Package.resolved is the dependency lockfile, either in the project root (pure Swift project)
 	// or at project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-	key = `{{ .OS }}-{{ .Arch }}-spm-cache-{{ checksum "**/Package.resolved" }}`	
+	key = `{{ .OS }}-{{ .Arch }}-spm-cache-{{ checksum "**/Package.resolved" }}`
 )
 
 type Input struct {
-	Verbose bool `env:"verbose,required"`
+	Verbose         bool   `env:"verbose,required"`
 	DerivedDataPath string `env:"derived_data_path,required"`
 }
 
@@ -57,8 +58,10 @@ func (step SaveCacheStep) Run() error {
 	if err := step.inputParser.Parse(&input); err != nil {
 		return fmt.Errorf("failed to parse inputs: %w", err)
 	}
-	path := fmt.Sprintf("%s/SourcePackages", input.DerivedDataPath)
 	stepconf.Print(input)
+
+	path := filepath.Join(input.DerivedDataPath, "SourcePackages")
+
 	step.logger.Println()
 	step.logger.Printf("Cache key: %s", key)
 	step.logger.Printf("Cache paths:")

--- a/step/step.go
+++ b/step/step.go
@@ -17,16 +17,12 @@ const (
 	// OS + Arch: SPM works on Linux too, and Intel/ARM difference is important on macOS
 	// checksum: Package.resolved is the dependency lockfile, either in the project root (pure Swift project)
 	// or at project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-	key = `{{ .OS }}-{{ .Arch }}-spm-cache-{{ checksum "**/Package.resolved" }}`
-
-	// Cached path
-	// This folder contains the cloned git repos of packages
-	// The wildcard is for the unique project folder, such as `sample-swiftpm2-czkemcvuprosyehacrtonyiofjkk`
-	path = "~/Library/Developer/Xcode/DerivedData/**/SourcePackages"
+	key = `{{ .OS }}-{{ .Arch }}-spm-cache-{{ checksum "**/Package.resolved" }}`	
 )
 
 type Input struct {
 	Verbose bool `env:"verbose,required"`
+	DerivedDataPath string `env:"derived_data_path,required"`
 }
 
 type SaveCacheStep struct {
@@ -61,6 +57,7 @@ func (step SaveCacheStep) Run() error {
 	if err := step.inputParser.Parse(&input); err != nil {
 		return fmt.Errorf("failed to parse inputs: %w", err)
 	}
+	path := fmt.Sprintf("%s/SourcePackages", input.DerivedDataPath)
 	stepconf.Print(input)
 	step.logger.Println()
 	step.logger.Printf("Cache key: %s", key)


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

This is a proposed change that allows the `DerivedData` path to be passed as an optional parameter of this step. This is accomplished by adding a new input parameter `derived_data_path` as a required input, but with a default value that corresponds to the path that was previously hardcoded as part of this step. 

I'd understand if you don't want to accept this, but I believe it has some value without making the step any more unwieldy for the majority use case.
